### PR TITLE
add user context in error log

### DIFF
--- a/component.cc
+++ b/component.cc
@@ -28,6 +28,9 @@ REQUIRES_SERVICE_PLACEHOLDER(log_builtins);
 REQUIRES_SERVICE_PLACEHOLDER(log_builtins_string);
 REQUIRES_SERVICE_PLACEHOLDER(mysql_string_converter);
 REQUIRES_SERVICE_PLACEHOLDER(udf_registration);
+REQUIRES_SERVICE_PLACEHOLDER(mysql_current_thread_reader);
+REQUIRES_SERVICE_PLACEHOLDER(mysql_thd_security_context);
+REQUIRES_SERVICE_PLACEHOLDER(mysql_security_context_options);
 ADD_BROADCAST_SERVICE_PLACEHOLDERS
 
 SERVICE_TYPE(log_builtins) * log_bi;
@@ -98,6 +101,9 @@ BEGIN_COMPONENT_REQUIRES(password_breach_check)
 REQUIRES_SERVICE(log_builtins), REQUIRES_SERVICE(log_builtins_string),
     REQUIRES_SERVICE(mysql_string_converter),
     REQUIRES_SERVICE(udf_registration),
+    REQUIRES_SERVICE(mysql_current_thread_reader),
+    REQUIRES_SERVICE(mysql_thd_security_context),
+    REQUIRES_SERVICE(mysql_security_context_options),
     ADD_BROADCAST_SERVICE_DEPENDENCIES END_COMPONENT_REQUIRES();
 
 /* component description */

--- a/password_breach_check.cc
+++ b/password_breach_check.cc
@@ -136,8 +136,23 @@ long long Breach_checker::check() const {
       /* Last entry in the list. There is no new line at the end of the list. */
       count = std::stoll(out_data.substr(pos + 1));
     }
+    // We need to get some info like user and host
+    Security_context_handle ctx = nullptr;
+    MYSQL_THD thd;
+    mysql_service_mysql_current_thread_reader->get(&thd);
+    mysql_service_mysql_thd_security_context->get(thd, &ctx);
+    MYSQL_LEX_CSTRING user; 
+    MYSQL_LEX_CSTRING host;
+
+    mysql_service_mysql_security_context_options->get(ctx, "priv_user",
+                                                        &user);
+  
+    mysql_service_mysql_security_context_options->get(ctx, "priv_host",
+                                                        &host);
+
     std::stringstream error_message;
     error_message << "The password with SHA1 prefix '" << prefix
+                  << "' entered by '" << user.str << "'@'" << host.str
                   << "' has appeared " << count
                   << " times in password breaches.";
     raise_error(error_message.str().c_str(), WARNING_LEVEL);

--- a/password_breach_check.h
+++ b/password_breach_check.h
@@ -29,6 +29,9 @@ THE SOFTWARE. */
 #include <mysql/components/services/mysql_string.h>
 #include <mysql/components/services/udf_registration.h>
 #include <mysql/components/services/validate_password.h>
+#include <mysql/components/services/security_context.h>
+#include <mysql/components/services/mysql_current_thread_reader.h>
+
 
 #include <sstream> /* std::stringstream */
 #include <string>  /* std::string */
@@ -38,6 +41,9 @@ extern REQUIRES_SERVICE_PLACEHOLDER(log_builtins);
 extern REQUIRES_SERVICE_PLACEHOLDER(log_builtins_string);
 extern REQUIRES_SERVICE_PLACEHOLDER(mysql_string_converter);
 extern REQUIRES_SERVICE_PLACEHOLDER(udf_registration);
+extern REQUIRES_SERVICE_PLACEHOLDER(mysql_thd_security_context);
+extern REQUIRES_SERVICE_PLACEHOLDER(mysql_security_context_options);
+extern REQUIRES_SERVICE_PLACEHOLDER(mysql_current_thread_reader);
 
 namespace password_breach_check {
 


### PR DESCRIPTION
Hi Harin, 

I've added the security context to display the user and the host in the error log message:

```
2025-02-10T16:25:10.136026Z 9 [Warning] [MY-000000] [Server] password_breach_check component reported: The password with SHA1 prefix '9CF95' entered by 'root'@'localhost' has appeared 595472 times in password breaches.
```